### PR TITLE
design: 메인페이지 레이아웃

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import MainPage from './pages/MainPage';
-
+// import MainPage from './pages/MainPage';
+import { BrowserRouter } from 'react-router-dom';
+import Routes from './routes/Routes';
 function App() {
   return (
-    <div>
-      <MainPage />
-    </div>
+    <BrowserRouter>
+      <Routes />
+    </BrowserRouter>
   );
 }
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,5 @@
+const Header = () => {
+  return <header className="h-[50px] bg-blue-500 text-white">Header</header>;
+};
+
+export default Header;

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom';
+import Header from '../components/layout/Header';
+const Layout = () => {
+  return (
+    <div className="h-dvh flex flex-col">
+      <Header />
+      <main className="flex-1 overflow-auto">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,7 +1,21 @@
 export default function MainPage() {
   return (
-    <div className=''>
-      메인페이지
+    <div className="w-screen flex pt-[30px]">
+      <div className="max-w-[1280px] mx-auto flex relative">
+        <div className="flex gap-5 w-[1000px] bg-blue-100 px-[30px] pt-[30px]">
+          <div className="flex flex-col w-1/3 gap-3.5">
+            <div className="h-[500px] bg-blue-300">Box1</div>
+            <div className="h-[300px] bg-blue-400">Box4</div>
+          </div>
+          <div className="flex flex-col w-2/3 gap-3.5">
+            <div className="h-[600px] bg-blue-500">Box2</div>
+            <div className="h-[220px] bg-blue-600">Box5</div>
+          </div>
+        </div>
+        <div className="w-[250px] h-[500px] bg-blue-200 ml-[30px] absolute right-[-300px] ">
+          Box3
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -1,0 +1,15 @@
+import { Routes as ReactRouters, Route } from 'react-router-dom';
+import MainPage from '../pages/MainPage';
+import Layout from '../layout/Layout';
+
+const Routes = () => {
+  return (
+    <ReactRouters>
+      <Route path="/" element={<Layout />}>
+        <Route index element={<MainPage />} />
+      </Route>
+    </ReactRouters>
+  );
+};
+
+export default Routes;


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/1-mainPage-layout` → `dev`

## 📝 작업 내용

메인페이지 레이아웃 퍼블리싱

## 🌠 스크린샷

<img width="1708" height="945" alt="스크린샷 2025-08-01 오후 5 50 20" src="https://github.com/user-attachments/assets/a69005c2-5266-47f8-a4c5-7a28ba74b8b2" />


## ✏️ 기타 사항

일단 px로 했는데 확인해보시고 이상한 부분 있으면 말씀해주세요!
Box 부분 컴포넌트로 수정하시면 됩니다.


## 📌 이슈 번호

- #1 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 헤더 컴포넌트가 고정 높이와 파란색 배경으로 추가되었습니다.
  * 헤더와 메인 콘텐츠 영역을 포함하는 레이아웃 구조가 도입되어 중첩 라우팅을 지원합니다.
  * 클라이언트 사이드 라우팅이 활성화되었습니다.
  * 메인 페이지가 다중 컬럼과 다중 박스 레이아웃으로 업데이트되어 시각적 구조가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->