### PR TITLE
design:  Sidebar 컴포넌트 구현

### DIFF
--- a/src/components/main/Checkbox.tsx
+++ b/src/components/main/Checkbox.tsx
@@ -5,9 +5,9 @@ interface CheckboxProps {
 
 export default function Checkbox({ label, checked }: CheckboxProps) {
   return (
-    <div className="flex items-center space-x-2 p-[5px] w-[200px] h-[30px] bg-gray-200">
+    <div className="flex items-center space-x-2 p-[5px] h-[30px] bg-gray-200">
       <input type="checkbox" checked={checked} className="w-5 h-5 rounded" />
-      <span className="select-none">{label}</span>
+      <span className="select-none whitespace-nowrap">{label}</span>
     </div>
   );
 }

--- a/src/components/main/Sidebar.tsx
+++ b/src/components/main/Sidebar.tsx
@@ -1,0 +1,34 @@
+import QuestList from './QuestList';
+
+export default function Sidebar() {
+  return (
+    <section className="bg-[#d9d9d9] p-[30px] w-[300px]">
+      <section className="mb-[20px] flex flex-col gap-[8px]">
+        <div className="flex gap-[8px] items-center">
+          <span className="text-[20px] font-bold">MONEY</span>
+          <span className="text-[15px] font-bold">1200</span>
+        </div>
+        <p className="text-[15px]">퀘스트를 완료하고 money를 획득하세요.</p>
+      </section>
+
+      {/* 체크박스 리스트 */}
+      <section className="p-[15px] bg-[#919191] mb-[20px] rounded">
+        <h1 className="pb-[5px] text-[20px] font-bold text-white">TODO</h1>
+        <QuestList />
+      </section>
+
+      {/* 버튼 컴포넌트 추후 추가 예정 */}
+      <nav className="flex flex-col gap-[10px]">
+        <button className="w-full h-[50px] bg-[#919191] text-white rounded text-[20px] font-bold">
+          방 꾸미러 가기
+        </button>
+        <button className="w-full h-[50px] bg-[#919191] text-white rounded text-[20px] font-bold">
+          내 일기 보러가기
+        </button>
+        <button className="w-full h-[50px] bg-[#919191] text-white rounded text-[20px] font-bold">
+          상점 가기
+        </button>
+      </nav>
+    </section>
+  );
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,21 +1,25 @@
+import Sidebar from '../components/main/Sidebar';
+
 export default function MainPage() {
   return (
-    <div className="w-screen flex pt-[30px]">
+    <main className="w-screen flex pt-[30px]">
       <div className="max-w-[1280px] mx-auto flex relative">
-        <div className="flex gap-5 w-[1000px] bg-blue-100 px-[30px] pt-[30px]">
-          <div className="flex flex-col w-1/3 gap-3.5">
-            <div className="h-[500px] bg-blue-300">Box1</div>
-            <div className="h-[300px] bg-blue-400">Box4</div>
-          </div>
-          <div className="flex flex-col w-2/3 gap-3.5">
-            <div className="h-[600px] bg-blue-500">Box2</div>
-            <div className="h-[220px] bg-blue-600">Box5</div>
-          </div>
-        </div>
-        <div className="w-[250px] h-[500px] bg-blue-200 ml-[30px] absolute right-[-300px] ">
-          Box3
-        </div>
+        <section className="flex gap-5 w-[1000px] bg-blue-100 px-[30px] pt-[30px]">
+          <aside className="flex flex-col w-1/3 gap-3.5">
+            <article className="h-[500px] bg-blue-300">Box1</article>
+            <article className="h-[300px] bg-blue-400">Box4</article>
+          </aside>
+
+          <section className="flex flex-col w-2/3 gap-3.5">
+            <article className="h-[600px] bg-blue-500">Box2</article>
+            <article className="h-[220px] bg-blue-600">Box5</article>
+          </section>
+        </section>
+
+        <aside className="w-[300px] ml-[30px]">
+          <Sidebar />
+        </aside>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## 🚀 반영 브랜치

`design/5-box-ui` → `dev`

## 📝 작업 내용

- 사이드바 UI 컴포넌트 구현
- 체크박스 컴포넌트에 텍스트 줄바꿈 방지를 위해 `whitespace-nowrap` 속성 추가
- 메인페이지 레이아웃에 사이드바 적용
- 메인페이지에 시맨틱 태그 적용하여 마크업 개선

## 🌠 스크린샷
<img width="481" height="864" alt="image" src="https://github.com/user-attachments/assets/300fd25e-8ec7-4b5b-9e88-f39d4a570241" />


## ✏️ 후속 작업
- 사이드바에 nav 부분 소민님이 버튼 컴포넌트 완성하면 적용할 예정

## 📌 이슈 번호

- #5 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 새로운 사이드바 컴포넌트가 추가되어 메인 페이지 우측에 표시됩니다. 사이드바에는 머니 표시, 퀘스트 리스트, 주요 네비게이션 버튼이 포함되어 있습니다.

* **Style**
  * 체크박스 컴포넌트의 컨테이너가 유동적으로 크기가 조정되며, 라벨 텍스트가 줄바꿈 없이 한 줄로 표시됩니다.
  * 메인 페이지의 레이아웃이 더 의미 있는 HTML5 시맨틱 태그로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->