### PR TITLE
design: Button 컴포넌트 구현

### DIFF
--- a/src/components/main/Button.tsx
+++ b/src/components/main/Button.tsx
@@ -1,0 +1,28 @@
+type ButtonSize = 's' | 'm' | 'l';
+
+interface ButtonProps {
+  size?: ButtonSize;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+const sizeClasses: Record<ButtonSize, string> = {
+  s: 'px-3 py-1 text-sm',
+  m: 'px-4 py-2 text-base',
+  l: 'px-6 py-3 text-lg',
+};
+
+export const Button: React.FC<ButtonProps> = ({
+  size = 'm',
+  onClick,
+  children,
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded bg-gray-400 hover:bg-gray-500 text-white font-medium ${sizeClasses[size]}`}
+    >
+      {children}
+    </button>
+  );
+};


### PR DESCRIPTION
## 🚀 반영 브랜치

`design/7-design-button` → `dev`

## 📝 작업 내용

- 버튼 컴포넌트를 구현하였습니다.
- 사이즈는 임의로 설정하였습니다. ("s", "m", "l" 구분)
- props로 받는 값은 onClick과 children입니다.

## 🌠 스크린샷

<img width="615" height="220" alt="Screenshot 2025-08-05 at 1 00 31 AM" src="https://github.com/user-attachments/assets/0a8dd245-3377-4d2f-b4a2-aa2d794f2355" />

## ✏️ 후속 작업

- 프로그래스바 제작

## 📌 이슈 번호

- #7
